### PR TITLE
Added support for keycloak 22. catch isn't recognized by the gwt comp…

### DIFF
--- a/src/main/java/org/realityforge/gwt/keycloak/Keycloak.java
+++ b/src/main/java/org/realityforge/gwt/keycloak/Keycloak.java
@@ -395,7 +395,7 @@ public class Keycloak
     static native KeycloakImpl create( @Nonnull final Keycloak keycloak, @Nonnull final String configURL )
       /*-{
 
-        var impl = $wnd.Keycloak(configURL);
+        var impl = new $wnd.Keycloak(configURL);
 
         impl.wrapper = keycloak;
         impl.onReady = $entry(function(authenticated) {
@@ -549,7 +549,8 @@ public class Keycloak
         $entry(function() {
           keycloak.wrapper.@org.realityforge.gwt.keycloak.Keycloak::onTokenUpdateFailure(*)(failureCallback);
         });
-      this.updateToken(minValiditySeconds).success(onSuccess).error(onFailure);
+      this.updateToken(minValiditySeconds)
+      .then(onSuccess);
     }-*/;
 
     /**


### PR DESCRIPTION
@realityforge could you please help me with this pull request. Keycloak.java in line 553 does not accept a .catch(onFailure); due to a syntax error. This change has to do with the change over to JavaScript Promises. Unfortunately I don't know what changes need to be done in GWT to make this work flawlessly. So for the time being an exception is thrown when there is an error with updating the token.